### PR TITLE
Support multiple APP_HOST and APP_PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN echo 'travis ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chef-solo -o java,xserver,firefox::tarball,chromium -j travis.json
 RUN wget http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar -O selenium-server.jar
 ADD start.sh start.sh
-CMD sh start.sh
+CMD bash start.sh
 EXPOSE 4444

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # start Xvfb
 /usr/bin/Xvfb :99 -ac -screen 0 1024x768x24 &
@@ -16,15 +16,25 @@ echo "$HOST_IP dockerhost" >> /etc/hosts
 # adding APP_HOST to list of known hosts
 if [ $APP_HOST ];
 then
-  echo "Registering host $APP_HOST"
-  echo "$HOST_IP $APP_HOST" >> /etc/hosts
+  HOSTS=(${APP_HOST//,/ });
+
+  for i in "${!HOSTS[@]}"
+  do
+    echo "Registering host ${HOSTS[i]}"
+    echo "$HOST_IP ${HOSTS[i]}" >> /etc/hosts
+  done;
 fi;
 
-# if onlu port provided - redirect to host+port
+# if only port provided - redirect to host+port
 if [ $APP_PORT ];
 then
-  echo "Registering port $APP_PORT"
-  socat TCP4-LISTEN:$APP_PORT,fork,reuseaddr TCP4:dockerhost:$APP_PORT &
+  PORTS=(${APP_PORT//,/ });
+
+  for i in "${!PORTS[@]}"
+  do
+    echo "Registering port ${PORTS[i]}"
+    socat TCP4-LISTEN:${PORTS[i]},fork,reuseaddr TCP4:dockerhost:${PORTS[i]} &
+  done;
 fi;
 
 # starting selenium

--- a/start.sh
+++ b/start.sh
@@ -14,15 +14,15 @@ echo "Host IP: $HOST_IP"
 echo "$HOST_IP dockerhost" >> /etc/hosts
 
 # adding APP_HOST to list of known hosts
-if [ $APP_HOST ]; 
-then 
+if [ $APP_HOST ];
+then
   echo "Registering host $APP_HOST"
-  echo "$HOSTIP $APP_HOST" >> /etc/hosts
+  echo "$HOST_IP $APP_HOST" >> /etc/hosts
 fi;
 
 # if onlu port provided - redirect to host+port
-if [ $APP_PORT ]; 
-then 
+if [ $APP_PORT ];
+then
   echo "Registering port $APP_PORT"
   socat TCP4-LISTEN:$APP_PORT,fork,reuseaddr TCP4:dockerhost:$APP_PORT &
 fi;


### PR DESCRIPTION
In my codeception setup, I have different suites running for various subdomains. As such, I need the ability to forward multiple hostnames. This patch will make it possible to pass in multiple hostnames as well as multiple ports, like so: 

`docker run -it -p 4444:4444 -e APP_HOST=host1,host2,host3 -e APP_PORT=8080,8888 davert/selenium-env`

EDIT: oh, this also includes the fix from #2
