### PR TITLE
Support changing Xvfb resolution

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,9 @@ if [ ! $RESOLUTION ];
 then
   RESOLUTION="1024x768x24"
 fi;
+
 echo "Running Xvfb at $RESOLUTION"
+
 /usr/bin/Xvfb :99 -ac -screen 0 $RESOLUTION &
 export DISPLAY=:99.0
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # start Xvfb
-/usr/bin/Xvfb :99 -ac -screen 0 1024x768x24 &
+if [ ! $RESOLUTION ];
+then
+  RESOLUTION="1024x768x24"
+fi;
+echo "Running Xvfb at $RESOLUTION"
+/usr/bin/Xvfb :99 -ac -screen 0 $RESOLUTION &
 export DISPLAY=:99.0
 
 # get host ip


### PR DESCRIPTION
Added `RESOLUTION` environment flag to change the display setting for xvfb. I ran into an issue where a site I was working with had dialogs which were too large to fit onscreen with 1024x768, causing failing tests (when I'm not trying to test for resolution fits). 
